### PR TITLE
use https for sparkle URL

### DIFF
--- a/releases/index.md
+++ b/releases/index.md
@@ -21,7 +21,7 @@ If you would like to receive automatic updates for beta versions in addition to
 release versions, please update to our beta SU feed by running the following
 command:
 
-    $ defaults write org.macosforge.xquartz.X11 SUFeedURL http://www.xquartz.org/releases/sparkle/beta.xml
+    $ defaults write org.macosforge.xquartz.X11 SUFeedURL https://www.xquartz.org/releases/sparkle/beta.xml
 
 #### MacPorts ####
 


### PR DESCRIPTION
... to prevent MITM hijacking of the updater's queries.
